### PR TITLE
Fix missing asset import

### DIFF
--- a/WebUI/src/Navbar/Navbar.tsx
+++ b/WebUI/src/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import { cx } from "../util"
 import util from "../util.module.css"
-import logo from "../assets/logo.png"
+import logo from "../assets/react.svg"
 import styles from "./Navbar.module.css"
 
 export interface INavbar


### PR DESCRIPTION
## Summary
- update path for navigation bar logo

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6848ac085ef48324a681ba116198e70a